### PR TITLE
Fix production build script

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,24 +4,18 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 
-module.exports = (env, argv) => {
-  console.log('env:');
-  console.dir(env);
-
-  console.log('argv:');
-  console.dir(argv);
-
+module.exports = ({ mode } = { mode: "development" }) => {
   const plugins = [
     new HtmlWebpackPlugin({template: "./public/index.html"}),
     new MiniCssExtractPlugin(),
   ]
 
-  if (env.mode === 'development') {
+  if (mode === 'development') {
     plugins.push(new ReactRefreshPlugin())
   }
 
   return {
-    mode: env.mode,
+    mode: mode,
     entry: "./src/index.js",
     devServer: {
       client: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,66 +4,70 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 
-module.exports = ({ mode } = { mode: "development" }) => {
-    console.log(`mode is: ${mode}`);
+module.exports = (env, argv) => {
+  console.log('env:');
+  console.dir(env);
 
-    return {
-            mode,
-            entry: "./src/index.js",
-            devServer: {
-                client: { 
-                    overlay: false,
-                    logging: 'warn' },
-            },
-            output: {
-                publicPath: "/",
-                path: path.resolve(__dirname, "build"),
-                filename: "bundle.js"
-            },
-            module: {
-                rules: [
-                    {
-                        test: /\.(js|jsx)$/,
-                        exclude: /node_modules/,
-                        use: "babel-loader"
-                    },
-                    // {
-                    //     test: /\.(png|svg|jpg|jpeg|gif|ico)$/,
-                    //     exclude: /node_modules/,
-                    //     use: ["url-loader", "file-loader"],
-                    // },
-                    {
-                        test: /\.(gif|png|jpe?g)$/,
-                        use: [
-                          {
-                            loader: 'file-loader',
-                            options: {
-                              name: '[name].[ext]',
-                              outputPath: 'assets/images/'
-                            }
-                          }
-                        ]
-                      },
-                    {
-                        test: /\.sa?css$/,
-                        exclude: /node_modules/,
-                        use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader", "sass-loader"]
-                    },
-                    {
-                        test: /\.css$/i,
-                        exclude: /node-modules/,
-                        use: [
-                            'style-loader',
-                            'css-loader'
-                        ]
-                    }
-                ]
-            },
-            plugins: [
-                new HtmlWebpackPlugin({template: "./public/index.html"}),
-                new ReactRefreshPlugin(),
-                new MiniCssExtractPlugin(),
-            ],
+  console.log('argv:');
+  console.dir(argv);
+
+  const plugins = [
+    new HtmlWebpackPlugin({template: "./public/index.html"}),
+    new MiniCssExtractPlugin(),
+  ]
+
+  if (env.mode === 'development') {
+    plugins.push(new ReactRefreshPlugin())
+  }
+
+  return {
+    mode: env.mode,
+    entry: "./src/index.js",
+    devServer: {
+      client: {
+        overlay: false,
+        logging: 'warn'
+      },
+    },
+    output: {
+      publicPath: "/",
+      path: path.resolve(__dirname, "build"),
+      filename: "bundle.js"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: "babel-loader"
+        },
+        {
+          test: /\.(gif|png|jpe?g)$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                name: '[name].[ext]',
+                outputPath: 'assets/images/'
+              }
+            }
+          ]
+        },
+        {
+          test: /\.sa?css$/,
+          exclude: /node_modules/,
+          use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader", "sass-loader"]
+        },
+        {
+          test: /\.css$/i,
+          exclude: /node-modules/,
+          use: [
+            'style-loader',
+            'css-loader'
+          ]
         }
-
+      ]
+    },
+    plugins: plugins,
+  }
 };


### PR DESCRIPTION
Addresses: [Issue: 2](https://github.com/cgseabaugh/sprawling-rpg/issues/2)

Wherein we update the `webpack` config to exclude development only plugins from  the production build.

## Background

Running `npm run prod` to build the production bundle, was erring with the following:

```
React Refresh Babel transform should only be enabled in development environment. 
Instead, the environment is: "production"
```

The `webpack` config was including the React Refresh Plugin regardless of the mode `webpack` was run under.

## Changes

Conditionally includes the React Refresh Plugin iff `webpack` is run in `development` mode.

## How Tested

Ran `npm run prod` locally, verified the reported error is resolved.

## Todos

In follow up PR address the following error during build step:

```
[webpack-cli] Error: Prevent writing to file that only differs in casing or query string from already written file.
This will lead to a race-condition and corrupted files on case-insensitive file systems.
/Users/matt/dev/sprawling-rpg/build/assets/images/assassin.png
/Users/matt/dev/sprawling-rpg/build/assets/images/Assassin.png
    at checkSimilarFile (/Users/matt/dev/sprawling-rpg/node_modules/webpack/lib/Compiler.js:666:11)
    at writeOut (/Users/matt/dev/sprawling-rpg/node_modules/webpack/lib/Compiler.js:848:11)
    at /Users/matt/dev/sprawling-rpg/node_modules/webpack/lib/util/fs.js:242:5
    at FSReqCallback.oncomplete (node:fs:188:23)
```